### PR TITLE
Refactor to replace EstateManagement with TransactionProcessor

### DIFF
--- a/TransactionProcessing.SchedulerService/DataGenerator/Program.cs
+++ b/TransactionProcessing.SchedulerService/DataGenerator/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using TransactionProcessing.SchedulerService.DataGenerator;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Merchant;
 
 namespace TransactionDataGenerator{
     using System.Collections.Generic;
@@ -7,9 +9,6 @@ namespace TransactionDataGenerator{
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using EstateManagement.Client;
-    using EstateManagement.DataTransferObjects.Responses.Contract;
-    using EstateManagement.DataTransferObjects.Responses.Merchant;
     using SecurityService.Client;
     using TransactionProcessor.Client;
 
@@ -17,8 +16,7 @@ namespace TransactionDataGenerator{
     /// 
     /// </summary>
     class Program{
-        private static EstateClient EstateClient;
-        
+       
         private static SecurityServiceClient SecurityServiceClient;
         
         private static TransactionProcessorClient TransactionProcessorClient;
@@ -38,9 +36,6 @@ namespace TransactionDataGenerator{
 
             baseAddressFunc = (apiName) => {
                                   String ipaddress = "192.168.1.167";
-                                  if (apiName == "EstateManagementApi"){
-                                      return $"http://{ipaddress}:5000";
-                                  }
 
                                   if (apiName == "SecurityService"){
                                       return $"https://{ipaddress}:5001";
@@ -65,8 +60,6 @@ namespace TransactionDataGenerator{
 
             Program.SecurityServiceClient = new SecurityServiceClient(baseAddressFunc, httpClient);
 
-            Program.EstateClient = new EstateClient(baseAddressFunc, httpClient, 2);
-
             Program.TransactionProcessorClient = new TransactionProcessorClient(baseAddressFunc, httpClient);
 
             // Set an estate
@@ -77,9 +70,8 @@ namespace TransactionDataGenerator{
             String clientId = "serviceClient";
             String clientSecret = "d192cbc46d834d0da90e8a9d50ded543";
             ITransactionDataGeneratorService g = new TransactionDataGeneratorService(Program.SecurityServiceClient,
-                                                                       Program.EstateClient,
                                                                        Program.TransactionProcessorClient,
-                                                                       Program.baseAddressFunc("EstateManagementApi"),
+                                                                       Program.baseAddressFunc("TransactionProcessorApi"),
                                                                        Program.baseAddressFunc("FileProcessorApi"),
                                                                        Program.baseAddressFunc("TestHostApi"),
                                                                        clientId,

--- a/TransactionProcessing.SchedulerService/JobTestDriver/Program.cs
+++ b/TransactionProcessing.SchedulerService/JobTestDriver/Program.cs
@@ -6,7 +6,6 @@ using TransactionProcessing.SchedulerService.Jobs.Jobs;
 
 namespace JobTestDriver
 {
-    using EstateManagement.Client;
     using MessagingService.Client;
     using NLog.LayoutRenderers.Wrappers;
     using SecurityService.Client;
@@ -50,18 +49,17 @@ namespace JobTestDriver
                 }
             };
             HttpClient client = new HttpClient(handler);
-            ISecurityServiceClient securityServiceClient = new SecurityServiceClient(delegate (String s) { return "https://192.168.1.167:5001"; }, client); IEstateClient estateClient = new EstateClient(delegate (String s) { return "http://192.168.1.167:5000"; }, client);
+            ISecurityServiceClient securityServiceClient = new SecurityServiceClient(delegate (String s) { return "https://192.168.1.167:5001"; }, client);
             ITransactionProcessorClient transactionProcessorClient = new TransactionProcessorClient(delegate (String s) { return "https://eojrtqfzvyheu0l.m.pipedream.net"; }, client);
-            String estateManagementApi = "http://192.168.1.167:5000";
+            String transactionProcessorApi = "http://192.168.1.167:5002";
             String fileProcessorApi = "http://192.168.1.167:5009";
             String testHostApi = "http://192.168.1.167:9000";
             String clientId = "serviceClient";
             String clientSecret = "d192cbc46d834d0da90e8a9d50ded543";
 
             ITransactionDataGeneratorService t = new TransactionDataGeneratorService(securityServiceClient,
-                                                                       estateClient,
                                                                        transactionProcessorClient,
-                                                                       estateManagementApi,
+                                                                       transactionProcessorApi,
                                                                        fileProcessorApi,
                                                                        testHostApi,
                                                                        clientId,
@@ -69,7 +67,7 @@ namespace JobTestDriver
                                                                        RunningMode.WhatIf);
             Guid estateId = Guid.Parse("435613ac-a468-47a3-ac4f-649d89764c22");
 
-            MakeFloatCreditsJobConfig c = new MakeFloatCreditsJobConfig(clientId,clientSecret, estateManagementApi, fileProcessorApi,"","", "", estateId,
+            MakeFloatCreditsJobConfig c = new MakeFloatCreditsJobConfig(clientId,clientSecret, fileProcessorApi,"","", transactionProcessorApi, estateId,
                 new List<DepositAmount> { new DepositAmount(Guid.NewGuid(), Guid.NewGuid(), 100) }
             );
 

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.DataGenerator/ITransactionDataGeneratorService.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.DataGenerator/ITransactionDataGeneratorService.cs
@@ -1,8 +1,8 @@
-﻿using EstateManagement.DataTransferObjects.Responses.Contract;
-using EstateManagement.DataTransferObjects.Responses.Merchant;
-using SimpleResults;
+﻿using SimpleResults;
 using System.Text.Json;
 using TransactionProcessor.DataTransferObjects;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Merchant;
 
 namespace TransactionProcessing.SchedulerService.DataGenerator;
 

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.DataGenerator/TransactionProcessing.SchedulerService.DataGenerator.csproj
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.DataGenerator/TransactionProcessing.SchedulerService.DataGenerator.csproj
@@ -7,11 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EstateManagement.Client" Version="2025.1.1" />
     <PackageReference Include="SecurityService.Client" Version="2025.1.1" />
-    <PackageReference Include="Shared" Version="2025.1.1" />
+    <PackageReference Include="Shared" Version="2025.1.2" />
     <PackageReference Include="SimpleResults" Version="3.0.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2024.12.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2025.1.5-build147" />
   </ItemGroup>
 
 </Project>

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Bootstrapper.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Bootstrapper.cs
@@ -6,8 +6,6 @@ namespace TransactionProcessing.SchedulerService.Jobs;
 using System;
 using System.Diagnostics.Eventing.Reader;
 using System.Net.Http;
-using EstateManagement.Client;
-using EstateManagement.DataTransferObjects.Responses;
 using MessagingService.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Quartz;
@@ -40,14 +38,12 @@ public static class Bootstrapper{
         Bootstrapper.Services.AddSingleton(httpClient);
         Bootstrapper.Services.AddSingleton<ISecurityServiceClient, SecurityServiceClient>();
         Bootstrapper.Services.AddSingleton<IMessagingServiceClient, MessagingServiceClient>();
-        
         Bootstrapper.Services.AddSingleton<ITransactionProcessorClient, TransactionProcessorClient>();
         Bootstrapper.Services.AddSingleton<Func<String, String>>(container => serviceName =>
         {
             return serviceName switch
             {
                 "SecurityService" => configuration.SecurityService,
-                "EstateManagementApi" => configuration.EstateManagementApi,
                 "FileProcessorApi" => configuration.FileProcessorApi,
                 "TestHostApi" => configuration.TestHostApi,
                 "TransactionProcessorApi" => configuration.TransactionProcessorApi,
@@ -56,8 +52,6 @@ public static class Bootstrapper{
         });
 
 
-        Func<String, String> resolver1() => serviceName => configuration.EstateManagementApi;
-        Bootstrapper.Services.AddSingleton<IEstateClient>(new EstateClient(resolver1(), httpClient, 2));
         Bootstrapper.ServiceProvider = Bootstrapper.Services.BuildServiceProvider();
     }
 

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/BaseConfiguration.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/BaseConfiguration.cs
@@ -5,7 +5,6 @@ namespace TransactionProcessing.SchedulerService.Jobs.Configuration;
 public record BaseConfiguration(
     String ClientId,
     String ClientSecret,
-    String EstateManagementApi,
     String FileProcessorApi,
     String SecurityService,
     String TestHostApi,

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/FileUploadJobConfig.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/FileUploadJobConfig.cs
@@ -5,8 +5,7 @@ namespace TransactionProcessing.SchedulerService.Jobs.Configuration;
 
 public record FileUploadJobConfig(String ClientId,
                                   String ClientSecret,
-                                  String EstateManagementApi,
                                   String FileProcessorApi,
                                   String SecurityService,
                                   String TestHostApi,
-                                  String TransactionProcessorApi, Guid EstateId, Guid MerchantId, List<String> ContractNames, Guid UserId) : BaseConfiguration(ClientId, ClientSecret, EstateManagementApi, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);
+                                  String TransactionProcessorApi, Guid EstateId, Guid MerchantId, List<String> ContractNames, Guid UserId) : BaseConfiguration(ClientId, ClientSecret, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/MakeFloatCreditsJobConfig.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/MakeFloatCreditsJobConfig.cs
@@ -5,13 +5,12 @@ namespace TransactionProcessing.SchedulerService.Jobs.Configuration;
 
 public record MakeFloatCreditsJobConfig(String ClientId,
                                         String ClientSecret,
-                                        String EstateManagementApi,
                                         String FileProcessorApi,
                                         String SecurityService,
                                         String TestHostApi,
                                         String TransactionProcessorApi,
                                         Guid EstateId,
-                                        List<DepositAmount> DepositAmounts) : BaseConfiguration(ClientId, ClientSecret, EstateManagementApi, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);
+                                        List<DepositAmount> DepositAmounts) : BaseConfiguration(ClientId, ClientSecret, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);
 
 
 public record DepositAmount(Guid ContractId, Guid ProductId, Decimal Amount);

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/MerchantStatementJobConfig.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/MerchantStatementJobConfig.cs
@@ -4,8 +4,7 @@ namespace TransactionProcessing.SchedulerService.Jobs.Configuration;
 
 public record MerchantStatementJobConfig(String ClientId,
                                          String ClientSecret,
-                                         String EstateManagementApi,
                                          String FileProcessorApi,
                                          String SecurityService,
                                          String TestHostApi,
-                                         String TransactionProcessorApi,Guid EstateId) : BaseConfiguration(ClientId, ClientSecret, EstateManagementApi, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);
+                                         String TransactionProcessorApi,Guid EstateId) : BaseConfiguration(ClientId, ClientSecret, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/ReplayParkedQueueJobConfig.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/ReplayParkedQueueJobConfig.cs
@@ -4,8 +4,7 @@ namespace TransactionProcessing.SchedulerService.Jobs.Configuration;
 
 public record ReplayParkedQueueJobConfig(String ClientId,
                                          String ClientSecret,
-                                         String EstateManagementApi,
                                          String FileProcessorApi,
                                          String SecurityService,
                                          String TestHostApi,
-                                         String TransactionProcessorApi, String EventStoreAddress) : BaseConfiguration(ClientId, ClientSecret, EstateManagementApi, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);
+                                         String TransactionProcessorApi, String EventStoreAddress) : BaseConfiguration(ClientId, ClientSecret, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/SettlementJobConfig.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/SettlementJobConfig.cs
@@ -4,8 +4,7 @@ namespace TransactionProcessing.SchedulerService.Jobs.Configuration;
 
 public record SettlementJobConfig(String ClientId,
                                   String ClientSecret,
-                                  String EstateManagementApi,
                                   String FileProcessorApi,
                                   String SecurityService,
                                   String TestHostApi,
-                                  String TransactionProcessorApi, Guid EstateId) : BaseConfiguration(ClientId, ClientSecret, EstateManagementApi, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);
+                                  String TransactionProcessorApi, Guid EstateId) : BaseConfiguration(ClientId, ClientSecret, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/TransactionJobConfig.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Configuration/TransactionJobConfig.cs
@@ -5,8 +5,7 @@ namespace TransactionProcessing.SchedulerService.Jobs.Configuration;
 
 public record TransactionJobConfig(String ClientId,
                                    String ClientSecret,
-                                   String EstateManagementApi,
                                    String FileProcessorApi,
                                    String SecurityService,
                                    String TestHostApi,
-                                   String TransactionProcessorApi, Guid EstateId, Guid MerchantId, Boolean IsLogon, List<String> ContractNames) : BaseConfiguration(ClientId, ClientSecret, EstateManagementApi, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);
+                                   String TransactionProcessorApi, Guid EstateId, Guid MerchantId, Boolean IsLogon, List<String> ContractNames) : BaseConfiguration(ClientId, ClientSecret, FileProcessorApi, SecurityService, TestHostApi, TransactionProcessorApi);

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Jobs/BaseJob.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Jobs/BaseJob.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using EstateManagement.Client;
 using Quartz;
 using SecurityService.Client;
 using SecurityService.DataTransferObjects.Responses;
@@ -22,14 +21,12 @@ public abstract class BaseJob : IJob{
 
     protected ITransactionDataGeneratorService CreateTransactionDataGenerator(String clientId, String clientSecret, RunningMode runningMode){
         ISecurityServiceClient securityServiceClient = Bootstrapper.GetService<ISecurityServiceClient>();
-        IEstateClient estateClient = Bootstrapper.GetService<IEstateClient>();
         ITransactionProcessorClient transactionProcessorClient = Bootstrapper.GetService<ITransactionProcessorClient>();
         Func<String, String> baseAddressFunc = Bootstrapper.GetService<Func<String, String>>();
 
         ITransactionDataGeneratorService g = new TransactionDataGeneratorService(securityServiceClient,
-                                                                   estateClient,
                                                                    transactionProcessorClient,
-                                                                   baseAddressFunc("EstateManagementApi"),
+                                                                   baseAddressFunc("TransactionProcessorApi"),
                                                                    baseAddressFunc("FileProcessorApi"),
                                                                    baseAddressFunc("TestHostApi"),
                                                                    clientId,

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Jobs/Jobs.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Jobs/Jobs.cs
@@ -2,6 +2,8 @@
 using TransactionProcessing.SchedulerService.DataGenerator;
 using TransactionProcessing.SchedulerService.Jobs.Configuration;
 using TransactionProcessor.DataTransferObjects;
+using TransactionProcessor.DataTransferObjects.Responses.Contract;
+using TransactionProcessor.DataTransferObjects.Responses.Merchant;
 
 namespace TransactionProcessing.SchedulerService.Jobs.Jobs;
 
@@ -14,8 +16,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using EstateManagement.DataTransferObjects.Responses.Contract;
-using EstateManagement.DataTransferObjects.Responses.Merchant;
 using EventStore.Client;
 using MessagingService.Client;
 using MessagingService.DataTransferObjects;

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/TransactionProcessing.SchedulerService.Jobs.csproj
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/TransactionProcessing.SchedulerService.Jobs.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MessagingService.Client" Version="2024.12.1" />
     
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
-    <PackageReference Include="Shared" Version="2025.1.1" />
+    <PackageReference Include="Shared" Version="2025.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Quartz" Version="3.10.0" />

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.csproj
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.10.0" />
     <PackageReference Include="Quartz.Plugins.TimeZoneConverter" Version="3.10.0" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.10.0" />
-    <PackageReference Include="Shared" Version="2025.1.1" />
+    <PackageReference Include="Shared" Version="2025.1.2" />
     <PackageReference Include="SilkierQuartz" Version="5.0.356" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService/nlog.config
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService/nlog.config
@@ -5,7 +5,7 @@
 			<target name="logfile" xsi:type="File"
 			        fileName="/home/txnproc/trace/schedulerservice.log"
 			        layout="${date:format=dd/MM/yyyy HH\:mm\:ss.ffff} | ${level} | ${callsite:className=true} | ${message} | ${exception:format=type,method:maxInnerExceptionLevel=5:innerFormat=shortType,message,method:InnerExceptionSeparator= | }"
-				archiveFileName="/home/txnproc/trace/estatemanagement.{#####}.log"
+				archiveFileName="/home/txnproc/trace/schedulerservice.{#####}.log"
 			        archiveAboveSize="104857600"
 			        archiveNumbering="Sequence"
 			        concurrentWrites="true"

--- a/TransactionProcessor.HealthChecksUI/TransactionProcessor.HealthChecksUI/appsettings.preproduction.json
+++ b/TransactionProcessor.HealthChecksUI/TransactionProcessor.HealthChecksUI/appsettings.preproduction.json
@@ -3,10 +3,6 @@
   "HealthChecksUI": {
     "HealthChecks": [
       {
-        "Name": "Estate Management Service",
-        "Uri": "http://192.168.0.134:5000/healthui"
-      },
-      {
         "Name": "Security Service",
         "Uri": "https://192.168.0.134:5001/healthui"
       },

--- a/TransactionProcessor.HealthChecksUI/TransactionProcessor.HealthChecksUI/appsettings.staging.json
+++ b/TransactionProcessor.HealthChecksUI/TransactionProcessor.HealthChecksUI/appsettings.staging.json
@@ -3,10 +3,6 @@
   "HealthChecksUI": {
     "HealthChecks": [
       {
-        "Name": "Estate Management Service",
-        "Uri": "http://192.168.1.167:5000/health"
-      },
-      {
         "Name": "Security Service",
         "Uri": "https://192.168.1.167:5001/health"
       },

--- a/TransactionProcessor.SystemSetupTool/TransactionProcessor.SystemSetupTool.csproj
+++ b/TransactionProcessor.SystemSetupTool/TransactionProcessor.SystemSetupTool.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EstateManagement.Client" Version="2024.11.2-build132" />
     <PackageReference Include="EventStore.Client.Grpc.PersistentSubscriptions" Version="23.2.1" />
     <PackageReference Include="EventStore.Client.Grpc.ProjectionManagement" Version="23.2.1" />
     <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
@@ -28,8 +27,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SecurityService.Client" Version="2024.11.2-build74" />
-    <PackageReference Include="Shared" Version="2025.1.1" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2024.12.1" />
+    <PackageReference Include="Shared" Version="2025.1.2" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2025.1.5-build147" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit removes dependencies on the `EstateManagement` client and replaces them with the `TransactionProcessor` client across multiple files. Key changes include:

- Updated `Program.cs` to initialize only `TransactionProcessorClient` and `SecurityServiceClient`.
- Refactored `TransactionDataGeneratorService` to utilize `TransactionProcessorClient` for all operations.
- Removed `EstateManagement.Client` package reference and updated `TransactionProcessor.Client` version in project files.
- Modified configuration files to eliminate health check entries for the `Estate Management Service`.
- Refactored `EstateSetupFunctions` to replace all `EstateClient` calls with `TransactionProcessorClient`.
- Updated `Bootstrapper` to remove `IEstateClient` registration and ensure proper dependency injection for `TransactionProcessorClient`.
- Adjusted job configuration classes to reference `TransactionProcessorApi` instead of `EstateManagementApi`.

These changes enhance maintainability and streamline the architecture by consolidating functionality under the `TransactionProcessor` client.