### PR TITLE
Add timeDelay parameter to SendSales method

### DIFF
--- a/TransactionProcessing.SchedulerService/DataGenerator/Program.cs
+++ b/TransactionProcessing.SchedulerService/DataGenerator/Program.cs
@@ -193,9 +193,8 @@ namespace TransactionDataGenerator{
                         foreach (ContractResponse contract in getMerchantContractsResult.Data) {
                             // Generate and send some sales
 
-                            await g.SendSales(dateTime, merchant, contract, 0, cancellationToken);
+                            await g.SendSales(dateTime, merchant, contract, 0,0, cancellationToken);
                         }
-
                     }
                 }
 

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.DataGenerator/ITransactionDataGeneratorService.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.DataGenerator/ITransactionDataGeneratorService.cs
@@ -22,7 +22,7 @@ public interface ITransactionDataGeneratorService
                                                 Guid estateId,
                                                 Guid merchantId,
                                                 CancellationToken cancellationToken);
-    Task<Result> SendSales(DateTime dateTime, MerchantResponse merchant, ContractResponse contract, Int32 numberOfSales, CancellationToken cancellationToken);
+    Task<Result> SendSales(DateTime dateTime, MerchantResponse merchant, ContractResponse contract, Int32 numberOfSales, Int32 timeDelay, CancellationToken cancellationToken);
     Task<Result> SendUploadFile(DateTime dateTime, ContractResponse contract, MerchantResponse merchant, Guid userId, CancellationToken cancellationToken);
     Task<Result<MerchantResponse>> GetMerchant(Guid estateId, Guid merchantId, CancellationToken cancellationToken);
     Task<Result> GenerateMerchantStatement(Guid estateId, Guid merchantId, DateTime statementDateTime, CancellationToken cancellationToken);

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Jobs/Jobs.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.Jobs/Jobs/Jobs.cs
@@ -164,14 +164,14 @@ public static class Jobs {
         }
 
         Random r = new Random();
-        List<string> results = new List<string>();
+        List<string> results = new();
         foreach (ContractResponse contract in contracts) {
             if (config.ContractNames.Contains(contract.Description) == false)
                 continue;
 
             int numberOfSales = r.Next(2, 4);
             // Generate and send some sales
-            Result saleResult = await t.SendSales(transactionDate, merchant, contract, numberOfSales, cancellationToken);
+            Result saleResult = await t.SendSales(transactionDate, merchant, contract, numberOfSales, 0,cancellationToken);
 
             if (saleResult.IsFailed) {
                 results.Add(contract.OperatorName);
@@ -179,7 +179,7 @@ public static class Jobs {
         }
 
         if (results.Any()) {
-            return Result.Failure($"Error sending sales files for merchant [{merchant.MerchantName}] [{string.Join(",", results)}]");
+            return Result.Failure($"Error sending sales files for merchant [{merchant.MerchantName}] [{String.Join(",", results)}]");
         }
 
         return Result.Success();

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.TickerQ/Configuration/BaseConfiguration.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.TickerQ/Configuration/BaseConfiguration.cs
@@ -10,50 +10,41 @@
 
     public class BaseConfiguration {
         public Boolean IsEnabled { get; set; } = true;
+        public Int32? TaskDelay { get; set; }
     }
 
-    public class ReplayParkedQueueJobConfiguration : BaseConfiguration
-    {
-        
-    }
+    public class ReplayParkedQueueJobConfiguration : BaseConfiguration;
 
-    public class MakeFloatCreditsJobConfiguration : BaseConfiguration
-    {
-
+    public class MakeFloatCreditsJobConfiguration : BaseConfiguration {
         public Guid EstateId { get; set; }
         public List<DepositAmount> DepositAmounts { get; set; } = new List<DepositAmount>();
     }
 
 
-    public class DepositAmount : BaseConfiguration
-    {
+    public class DepositAmount : BaseConfiguration {
         public Guid ContractId { get; set; }
         public Guid ProductId { get; set; }
         public Decimal Amount { get; set; }
     }
 
-    public class UploadTransactionFileJobConfiguration : BaseConfiguration
-{
+    public class UploadTransactionFileJobConfiguration : BaseConfiguration {
         public Guid EstateId { get; set; }
         public Guid MerchantId { get; set; }
         public Guid UserId { get; set; }
         public List<String> ContractsToInclude { get; set; }
-}
+    }
 
-    public class GenerateTransactionsJobConfiguration : BaseConfiguration
-{
+    public class GenerateTransactionsJobConfiguration : BaseConfiguration {
         public Guid EstateId { get; set; }
         public Guid MerchantId { get; set; }
     }
 
-    public class ProcessSettlementJobConfiguration : BaseConfiguration
-{
+    public class ProcessSettlementJobConfiguration : BaseConfiguration {
         public Guid EstateId { get; set; }
         public Guid MerchantId { get; set; }
     }
 
-    public class MerchantStatementJobConfiguration : BaseConfiguration
-{
+    public class MerchantStatementJobConfiguration : BaseConfiguration {
         public Guid EstateId { get; set; }
         public Guid MerchantId { get; set; }
     }

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.TickerQ/Jobs/Jobs.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.TickerQ/Jobs/Jobs.cs
@@ -107,7 +107,6 @@ namespace TransactionProcessing.SchedulerService.TickerQ.Jobs
                 Logger.LogWarning("Replay Parked Queue Job is not enabled");
                 return;
             }
-
             Result result = await Jobs.ReplayParkedQueues(this.BaseConfiguration.EventStoreAddress, ct);
 
             if (result.IsFailed) {
@@ -203,7 +202,7 @@ namespace TransactionProcessing.SchedulerService.TickerQ.Jobs
             };
 
             Result result = await Jobs.GenerateSaleTransactions(this.TransactionDataGeneratorService, tickerContext.Request.EstateId, 
-                tickerContext.Request.MerchantId, ct);
+                tickerContext.Request.MerchantId, tickerContext.Request.TaskDelay.GetValueOrDefault(0), ct);
             if (result.IsFailed)
             {
                 throw new ApplicationException(result.Message);
@@ -367,6 +366,7 @@ namespace TransactionProcessing.SchedulerService.TickerQ.Jobs
 
         public static async Task<Result> GenerateSaleTransactions(ITransactionDataGeneratorService t,
                                                           Guid estateId, Guid merchantId,
+                                                          Int32 timeDelay,
                                                           CancellationToken cancellationToken)
         {
             // get the merchant
@@ -400,7 +400,7 @@ namespace TransactionProcessing.SchedulerService.TickerQ.Jobs
             foreach (ContractResponse contract in contracts) {
                 int numberOfSales = r.Next(1, 2);
                 // Generate and send some sales
-                Result saleResult = await t.SendSales(transactionDate, merchant, contract, numberOfSales, cancellationToken);
+                Result saleResult = await t.SendSales(transactionDate, merchant, contract, numberOfSales, timeDelay, cancellationToken);
 
                 if (saleResult.IsFailed)
                 {

--- a/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.TickerQ/Jobs/Jobs.cs
+++ b/TransactionProcessing.SchedulerService/TransactionProcessing.SchedulerService.TickerQ/Jobs/Jobs.cs
@@ -398,7 +398,7 @@ namespace TransactionProcessing.SchedulerService.TickerQ.Jobs
             Random r = new Random();
             List<string> results = new List<string>();
             foreach (ContractResponse contract in contracts) {
-                int numberOfSales = r.Next(1, 2);
+                int numberOfSales = r.Next(1, 5);
                 // Generate and send some sales
                 Result saleResult = await t.SendSales(transactionDate, merchant, contract, numberOfSales, timeDelay, cancellationToken);
 


### PR DESCRIPTION
Updated the SendSales method in ITransactionDataGeneratorService to include a timeDelay parameter for processing sales. The TransactionDataGeneratorService class now incorporates this delay, allowing for random delays between sales transactions, with the number of sales adjusted to a range of 1 to 5. All relevant method calls have been updated to utilize the new parameter. Additionally, the BaseConfiguration class has a new nullable TaskDelay property, and the Jobs class has been modified to respect the configured delay. These changes enhance the flexibility and timing of the sales generation process.